### PR TITLE
Handle expired/invalid JWTs: explicit 401s and UI handling

### DIFF
--- a/backend/api/profile_routes.py
+++ b/backend/api/profile_routes.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from services.user_profile_service import build_user_profile
 from services.db import user_profiles_col
 from services.logger import AppLogger
-from api.utils import get_user_id_from_auth
+from api.utils import get_user_id_from_auth, require_user_id_from_auth
 
 router = APIRouter()
 logger = AppLogger.get_logger(__name__)
@@ -55,7 +55,7 @@ def promote_to_explicit(profile, keyword, weight=1.0):
 # --- Endpoints ---
 
 @router.get("/profiles/me")
-async def get_my_profile(user_id: str = Depends(get_user_id_from_auth)):
+async def get_my_profile(user_id: str = Depends(require_user_id_from_auth)):
     logger.debug("Fetching profile", extra={"user_id": user_id})
     profile = build_user_profile(user_id)
     if not profile:

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,18 +1,53 @@
-from fastapi import Header
+from fastapi import Header, HTTPException
 from services import auth_service
+from jose.exceptions import ExpiredSignatureError
+from jose import JWTError
 
 
 async def get_user_id_from_auth(authorization: str = Header(None)):
+    """
+    Permissive dependency: returns the `user_id` when a valid bearer token is provided,
+    otherwise returns the string "guest". This is suitable for endpoints that allow
+    anonymous access and should continue functioning for guests.
+    """
     if not authorization:
         return "guest"
     parts = authorization.split()
     if len(parts) != 2 or parts[0].lower() != "bearer":
         return "guest"
     token = parts[1]
-    payload = auth_service.decode_access_token(token)
-    if not payload:
-        # TODO: handle expired/invalid token properly:
-        #   - Option 1: forcefully log the user out
-        #   - Option 2: return an error explaining the token is expired
+    try:
+        payload = auth_service.decode_access_token(token)
+    except ExpiredSignatureError:
+        # Expired token — treat as guest for permissive endpoints so UI can show limited view
         return "guest"
+    except JWTError:
+        # Malformed/invalid token — treat as guest
+        return "guest"
+
     return payload.get("sub") or payload.get("user_id") or "guest"
+
+
+async def require_user_id_from_auth(authorization: str = Header(None)):
+    """
+    Strict dependency: requires a valid bearer token and returns the `user_id`.
+    Raises `HTTPException(status_code=401)` when the token is missing, expired, or invalid.
+    Use this for endpoints that must be accessed only by authenticated users.
+    """
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header missing")
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+    token = parts[1]
+    try:
+        payload = auth_service.decode_access_token(token)
+    except ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    user_id = payload.get("sub") or payload.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+    return user_id

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 import os
 from jose import JWTError, jwt
+from jose.exceptions import ExpiredSignatureError
 from passlib.context import CryptContext
 
 from services.db import users_col
@@ -76,8 +77,7 @@ def create_access_token(*, data: dict, expires_delta: Optional[timedelta] = None
         raise
 
 def decode_access_token(token: str) -> Optional[dict]:
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        return payload
-    except JWTError:
-        return None
+    # Let JWT-related errors propagate so callers can distinguish
+    # between expired and otherwise invalid tokens.
+    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    return payload

--- a/frontend/src/api/search.js
+++ b/frontend/src/api/search.js
@@ -1,18 +1,37 @@
 import axios from "axios";
-import { getAuthHeaders } from "../auth/auth.js";
+import { getAuthHeaders, clearCurrentUser } from "../auth/auth.js";
 
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 export async function searchQuery(query, useEnhanced = true) {
     const url = `${API_BASE}/search?q=${encodeURIComponent(query)}&use_enhanced=${useEnhanced}`;
     const headers = getAuthHeaders();
-    const res = await axios.get(url, { headers });
-    return res.data;
+    try {
+        const res = await axios.get(url, { headers });
+        return res.data;
+    } catch (err) {
+        if (err?.response?.status === 401) {
+            // Token expired or invalid — force logout and redirect to login
+            clearCurrentUser();
+            window.location.href = "/login";
+            return Promise.reject(new Error("Unauthorized: token expired or invalid"));
+        }
+        throw err;
+    }
 }
 
 export async function logClick({ user_id, query_id, clicked_url, rank }) {
     const url = `${API_BASE}/interactions`;
     const headers = { "Content-Type": "application/json", ...getAuthHeaders() };
     // If you pass user_id in the body it will be ignored if there's a logged-in user.
-    await axios.post(url, { user_id, query_id, clicked_url, rank }, { headers });
+    try {
+        await axios.post(url, { user_id, query_id, clicked_url, rank }, { headers });
+    } catch (err) {
+        if (err?.response?.status === 401) {
+            clearCurrentUser();
+            window.location.href = "/login";
+            return Promise.reject(new Error("Unauthorized: token expired or invalid"));
+        }
+        throw err;
+    }
 }


### PR DESCRIPTION
Description: Make auth handling explicit by adding a permissive get_user_id_from_auth and a strict require_user_id_from_auth dependency. Let JWT decode errors propagate so the API can return clear 401s for expired/invalid tokens. Require auth for sensitive endpoints (e.g. GET /profiles/me). Update frontend API calls to clear stored auth and redirect to /login on 401 responses. This prevents silent fallback to the guest user and improves UX/security by prompting re-login when tokens are invalid or expired.

Backend: auth_service.decode_access_token now surfaces JWT errors and utils.py exposes both permissive and strict dependencies. profile_routes.py uses the strict dependency for /profiles/me.

Frontend: search.js now handles 401 by clearing stored auth and redirecting to /login.

Future Testing: 
Unit: Test auth_service.decode_access_token behavior
Case: valid token → returns payload.
Case: expired token → raises ExpiredSignatureError.
Case: malformed token → raises JWTError.

FastAPI integration tests with TestClient:
GET /profiles/me with no Authorization header → assert 401 and detail "Authorization header missing".
GET /profiles/me with expired token → assert 401 and detail "Token expired".
GET /profiles/me with malformed token → assert 401 and detail "Invalid token".
GET /search (uses permissive dependency) with expired token → assert endpoint returns 200 and response consistent with guest flow (test that pipeline still completes).