### PR TITLE
Add tests for data_models and build_user_profiles

### DIFF
--- a/backend/tests/test_build_user_profiles.py
+++ b/backend/tests/test_build_user_profiles.py
@@ -1,0 +1,139 @@
+"""
+Tests for scripts/build_user_profiles.py – run_profile_build.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, call
+from io import StringIO
+
+
+class TestRunProfileBuild:
+    """Test cases for the run_profile_build script function."""
+
+    @patch("scripts.build_user_profiles.queries_col")
+    @patch("scripts.build_user_profiles.build_user_profile")
+    def test_no_users_found(self, mock_build, mock_queries_col, capsys):
+        """When there are no users, run_profile_build should print zero users and not build any profiles."""
+        # Arrange
+        mock_queries_col.distinct.return_value = []
+
+        # Act
+        from scripts.build_user_profiles import run_profile_build
+        run_profile_build()
+
+        # Assert
+        mock_queries_col.distinct.assert_called_once_with("user_id")
+        mock_build.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Found 0 users" in captured.out
+        assert "Done building all user profiles" in captured.out
+
+    @patch("scripts.build_user_profiles.queries_col")
+    @patch("scripts.build_user_profiles.build_user_profile")
+    def test_single_user(self, mock_build, mock_queries_col, capsys):
+        """With one user, build_user_profile should be called exactly once."""
+        # Arrange
+        mock_queries_col.distinct.return_value = ["user_1"]
+        mock_build.return_value = {
+            "implicit_interests": {"python": 0.9, "testing": 0.7}
+        }
+
+        # Act
+        from scripts.build_user_profiles import run_profile_build
+        run_profile_build()
+
+        # Assert
+        mock_build.assert_called_once_with("user_1")
+        captured = capsys.readouterr()
+        assert "Found 1 users" in captured.out
+        assert "user_1" in captured.out
+        assert "2 implicit interests" in captured.out
+
+    @patch("scripts.build_user_profiles.queries_col")
+    @patch("scripts.build_user_profiles.build_user_profile")
+    def test_multiple_users(self, mock_build, mock_queries_col, capsys):
+        """With multiple users, build_user_profile should be called once per user."""
+        # Arrange
+        user_ids = ["user_a", "user_b", "user_c"]
+        mock_queries_col.distinct.return_value = user_ids
+        mock_build.side_effect = [
+            {"implicit_interests": {"ml": 0.8}},
+            {"implicit_interests": {"web": 0.6, "css": 0.3}},
+            {"implicit_interests": {}},
+        ]
+
+        # Act
+        from scripts.build_user_profiles import run_profile_build
+        run_profile_build()
+
+        # Assert
+        assert mock_build.call_count == 3
+        mock_build.assert_any_call("user_a")
+        mock_build.assert_any_call("user_b")
+        mock_build.assert_any_call("user_c")
+        captured = capsys.readouterr()
+        assert "Found 3 users" in captured.out
+        assert "1 implicit interests" in captured.out   # user_a
+        assert "2 implicit interests" in captured.out   # user_b
+        assert "0 implicit interests" in captured.out   # user_c
+
+    @patch("scripts.build_user_profiles.queries_col")
+    @patch("scripts.build_user_profiles.build_user_profile")
+    def test_calls_in_order(self, mock_build, mock_queries_col):
+        """build_user_profile should be called in the same order users are returned."""
+        # Arrange
+        user_ids = ["alpha", "bravo", "charlie"]
+        mock_queries_col.distinct.return_value = user_ids
+        mock_build.return_value = {"implicit_interests": {}}
+
+        # Act
+        from scripts.build_user_profiles import run_profile_build
+        run_profile_build()
+
+        # Assert
+        expected_calls = [call("alpha"), call("bravo"), call("charlie")]
+        assert mock_build.call_args_list == expected_calls
+
+    @patch("scripts.build_user_profiles.queries_col")
+    @patch("scripts.build_user_profiles.build_user_profile")
+    def test_build_failure_propagates(self, mock_build, mock_queries_col):
+        """If build_user_profile raises an exception it should propagate up."""
+        # Arrange
+        mock_queries_col.distinct.return_value = ["failing_user"]
+        mock_build.side_effect = RuntimeError("DB connection lost")
+
+        # Act / Assert
+        from scripts.build_user_profiles import run_profile_build
+        with pytest.raises(RuntimeError, match="DB connection lost"):
+            run_profile_build()
+
+    @patch("scripts.build_user_profiles.queries_col")
+    @patch("scripts.build_user_profiles.build_user_profile")
+    def test_output_shows_partial_interests(self, mock_build, mock_queries_col, capsys):
+        """Output should include a slice of the implicit interests items."""
+        # Arrange
+        mock_queries_col.distinct.return_value = ["u1"]
+        interests = {f"topic_{i}": float(i) for i in range(10)}
+        mock_build.return_value = {"implicit_interests": interests}
+
+        # Act
+        from scripts.build_user_profiles import run_profile_build
+        run_profile_build()
+
+        # Assert – the script prints the first 8 items followed by "..."
+        captured = capsys.readouterr()
+        assert "..." in captured.out
+        assert "10 implicit interests" in captured.out
+
+    @patch("scripts.build_user_profiles.queries_col")
+    @patch("scripts.build_user_profiles.build_user_profile")
+    def test_distinct_called_with_correct_field(self, mock_build, mock_queries_col):
+        """queries_col.distinct should be called with 'user_id'."""
+        # Arrange
+        mock_queries_col.distinct.return_value = []
+
+        # Act
+        from scripts.build_user_profiles import run_profile_build
+        run_profile_build()
+
+        # Assert
+        mock_queries_col.distinct.assert_called_once_with("user_id")

--- a/backend/tests/test_data_models.py
+++ b/backend/tests/test_data_models.py
@@ -1,0 +1,191 @@
+"""
+Tests for models/data_models.py – make_query_doc, make_interaction_doc, make_user_profile_doc.
+"""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from models.data_models import (
+    make_query_doc,
+    make_interaction_doc,
+    make_user_profile_doc,
+)
+
+
+class TestMakeQueryDoc:
+    """Test cases for make_query_doc."""
+
+    def test_returns_required_keys(self):
+        """A query document should contain all expected keys."""
+        doc = make_query_doc(user_id="u1", raw_text="hello world")
+        assert set(doc.keys()) == {"_id", "user_id", "raw_text", "enhanced_text", "timestamp"}
+
+    def test_user_id_and_raw_text_stored(self):
+        """Supplied user_id and raw_text should appear verbatim in the document."""
+        doc = make_query_doc(user_id="user_42", raw_text="python tutorial")
+        assert doc["user_id"] == "user_42"
+        assert doc["raw_text"] == "python tutorial"
+
+    def test_enhanced_text_defaults_to_none(self):
+        """When enhanced_text is not provided it should be None."""
+        doc = make_query_doc(user_id="u1", raw_text="q")
+        assert doc["enhanced_text"] is None
+
+    def test_enhanced_text_stored_when_provided(self):
+        """When enhanced_text is provided it should be stored."""
+        doc = make_query_doc(user_id="u1", raw_text="q", enhanced_text="expanded q")
+        assert doc["enhanced_text"] == "expanded q"
+
+    def test_id_is_valid_uuid4(self):
+        """The _id field should be a valid UUID4 string."""
+        doc = make_query_doc(user_id="u1", raw_text="q")
+        parsed = uuid.UUID(doc["_id"], version=4)
+        assert str(parsed) == doc["_id"]
+
+    def test_id_is_unique_across_calls(self):
+        """Each call should generate a unique _id."""
+        ids = {make_query_doc("u1", "q")["_id"] for _ in range(50)}
+        assert len(ids) == 50
+
+    def test_timestamp_is_valid_utc_iso(self):
+        """Timestamp should be a parseable ISO-8601 string close to now."""
+        before = datetime.now(timezone.utc)
+        doc = make_query_doc(user_id="u1", raw_text="q")
+        after = datetime.now(timezone.utc)
+
+        ts = datetime.fromisoformat(doc["timestamp"])
+        assert before <= ts <= after
+
+    def test_empty_raw_text_accepted(self):
+        """An empty raw_text string should be stored without error."""
+        doc = make_query_doc(user_id="u1", raw_text="")
+        assert doc["raw_text"] == ""
+
+
+class TestMakeInteractionDoc:
+    """Test cases for make_interaction_doc."""
+
+    def test_returns_required_keys(self):
+        """An interaction document should contain all expected keys."""
+        doc = make_interaction_doc(
+            user_id="u1", query_id="q1", clicked_url="https://example.com", rank=1
+        )
+        assert set(doc.keys()) == {
+            "_id", "user_id", "query_id", "clicked_url", "rank", "timestamp", "action_type"
+        }
+
+    def test_fields_stored_correctly(self):
+        """All supplied field values should be stored verbatim."""
+        doc = make_interaction_doc(
+            user_id="u2", query_id="q3", clicked_url="https://foo.bar", rank=5
+        )
+        assert doc["user_id"] == "u2"
+        assert doc["query_id"] == "q3"
+        assert doc["clicked_url"] == "https://foo.bar"
+        assert doc["rank"] == 5
+
+    def test_action_type_defaults_to_click(self):
+        """Default action_type should be 'click'."""
+        doc = make_interaction_doc("u1", "q1", "https://a.com", 1)
+        assert doc["action_type"] == "click"
+
+    def test_action_type_positive_feedback(self):
+        """action_type should be stored when explicitly set to positive_feedback."""
+        doc = make_interaction_doc("u1", "q1", "https://a.com", 1, action_type="positive_feedback")
+        assert doc["action_type"] == "positive_feedback"
+
+    def test_action_type_negative_feedback(self):
+        """action_type should be stored when explicitly set to negative_feedback."""
+        doc = make_interaction_doc("u1", "q1", "https://a.com", 1, action_type="negative_feedback")
+        assert doc["action_type"] == "negative_feedback"
+
+    def test_id_is_valid_uuid4(self):
+        """The _id field should be a valid UUID4 string."""
+        doc = make_interaction_doc("u1", "q1", "https://a.com", 1)
+        parsed = uuid.UUID(doc["_id"], version=4)
+        assert str(parsed) == doc["_id"]
+
+    def test_id_is_unique_across_calls(self):
+        """Each call should produce a unique _id."""
+        ids = {make_interaction_doc("u1", "q1", "https://a.com", 1)["_id"] for _ in range(50)}
+        assert len(ids) == 50
+
+    def test_timestamp_is_valid_utc_iso(self):
+        """Timestamp should be a parseable ISO-8601 string close to now."""
+        before = datetime.now(timezone.utc)
+        doc = make_interaction_doc("u1", "q1", "https://a.com", 1)
+        after = datetime.now(timezone.utc)
+
+        ts = datetime.fromisoformat(doc["timestamp"])
+        assert before <= ts <= after
+
+    def test_rank_zero(self):
+        """A rank of 0 should be stored without error."""
+        doc = make_interaction_doc("u1", "q1", "https://a.com", 0)
+        assert doc["rank"] == 0
+
+
+class TestMakeUserProfileDoc:
+    """Test cases for make_user_profile_doc."""
+
+    def test_returns_required_keys(self):
+        """A user profile document should contain all expected keys."""
+        doc = make_user_profile_doc(
+            user_id="u1",
+            interests={"python": 0.9},
+            query_history=["q1"],
+            click_history=["https://a.com"],
+        )
+        expected_keys = {
+            "user_id", "implicit_interests", "query_history",
+            "click_history", "last_updated", "explicit_interests", "embedding"
+        }
+        assert set(doc.keys()) == expected_keys
+
+    def test_fields_stored_correctly(self):
+        """Supplied fields should appear verbatim in the document."""
+        interests = {"ml": 0.8, "web": 0.6}
+        q_hist = ["q1", "q2"]
+        c_hist = ["https://a.com"]
+        doc = make_user_profile_doc("u5", interests, q_hist, c_hist)
+        assert doc["user_id"] == "u5"
+        assert doc["implicit_interests"] == interests
+        assert doc["query_history"] == q_hist
+        assert doc["click_history"] == c_hist
+
+    def test_explicit_interests_defaults_to_empty_list(self):
+        """When explicit_interests is omitted it should default to an empty list."""
+        doc = make_user_profile_doc("u1", {}, [], [])
+        assert doc["explicit_interests"] == []
+
+    def test_explicit_interests_stored_when_provided(self):
+        """When explicit_interests is provided it should be stored."""
+        explicit = [{"keyword": "python", "weight": 1.0}]
+        doc = make_user_profile_doc("u1", {}, [], [], explicit_interests=explicit)
+        assert doc["explicit_interests"] == explicit
+
+    def test_explicit_interests_none_coerced_to_empty_list(self):
+        """Passing None for explicit_interests should yield an empty list."""
+        doc = make_user_profile_doc("u1", {}, [], [], explicit_interests=None)
+        assert doc["explicit_interests"] == []
+
+    def test_embedding_is_none(self):
+        """The embedding field should always be None at creation time."""
+        doc = make_user_profile_doc("u1", {}, [], [])
+        assert doc["embedding"] is None
+
+    def test_timestamp_is_valid_utc_iso(self):
+        """last_updated should be a parseable ISO-8601 string close to now."""
+        before = datetime.now(timezone.utc)
+        doc = make_user_profile_doc("u1", {}, [], [])
+        after = datetime.now(timezone.utc)
+
+        ts = datetime.fromisoformat(doc["last_updated"])
+        assert before <= ts <= after
+
+    def test_empty_interests_and_histories(self):
+        """Empty dicts/lists for interests and histories should be stored cleanly."""
+        doc = make_user_profile_doc("u1", {}, [], [])
+        assert doc["implicit_interests"] == {}
+        assert doc["query_history"] == []
+        assert doc["click_history"] == []


### PR DESCRIPTION

Adds unit tests for previously untested backend code in the models and scripts directories, bringing them in line with the existing test coverage for routes and services.


Validates keys, field storage, default/explicit values, UUID4 validity & uniqueness, UTC timestamp, and empty input handling

Verifies behavior with zero, one, and multiple users
Asserts correct call order
Validates stdout output formatting (user count, interest counts, partial interest preview)
Confirms exception propagation when profile building fails

All 32 tests currently pass