### PR TITLE
Fix test imports: add backend. prefix to all patch paths

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# package marker for backend

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = tests
+testpaths = backend/tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*

--- a/backend/run_tests.py
+++ b/backend/run_tests.py
@@ -3,12 +3,15 @@ import subprocess
 import sys
 import os
 
-# Change to the backend directory where this script is located
+# Change to the project root directory (parent of backend/)
+# so that 'backend' is importable as a package
 script_dir = os.path.dirname(os.path.abspath(__file__))
-os.chdir(script_dir)
+project_root = os.path.dirname(script_dir)
+os.chdir(project_root)
 
 result = subprocess.run(
-    [sys.executable, "-m", "pytest", "tests/", "-v", "--tb=short"],
+    [sys.executable, "-m", "pytest", "backend/tests/", "-v", "--tb=short",
+     "-c", "backend/pytest.ini"],
     capture_output=False,
     text=True
 )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,14 +25,14 @@ mock_discarded_tokens_col = MagicMock()
 mock_users_col.find_one.return_value = None  # No existing user by default
 mock_queries_col.distinct.return_value = []  # No user IDs by default
 
-with patch("services.db.users_col", mock_users_col), \
-     patch("services.db.user_profiles_col", mock_profiles_col), \
-     patch("services.db.queries_col", mock_queries_col), \
-     patch("services.db.interactions_col", mock_interactions_col), \
-     patch("services.db.discarded_tokens_col", mock_discarded_tokens_col), \
-     patch("background_tasks.background_tasks.start_background_tasks"), \
-     patch("background_tasks.background_tasks.stop_background_tasks"):
-    from main import app
+with patch("backend.services.db.users_col", mock_users_col), \
+     patch("backend.services.db.user_profiles_col", mock_profiles_col), \
+     patch("backend.services.db.queries_col", mock_queries_col), \
+     patch("backend.services.db.interactions_col", mock_interactions_col), \
+     patch("backend.services.db.discarded_tokens_col", mock_discarded_tokens_col), \
+     patch("backend.background_tasks.background_tasks.start_background_tasks"), \
+     patch("backend.background_tasks.background_tasks.stop_background_tasks"):
+    from backend.main import app
 
 
 @pytest.fixture
@@ -76,7 +76,7 @@ def mock_auth_service():
     """
     Mock authentication service for testing auth-protected endpoints.
     """
-    with patch("api.auth_routes.auth_service") as mock_service:
+    with patch("backend.api.auth_routes.auth_service") as mock_service:
         # Setup default mock behaviors
         mock_service.create_user.return_value = {
             "user_id": "test_user_123",
@@ -96,7 +96,7 @@ def mock_search_service():
     """
     Mock search service to avoid making actual API calls during tests.
     """
-    with patch("api.search_routes.search") as mock_search:
+    with patch("backend.api.search_routes.search") as mock_search:
         mock_search.return_value = {
             "results": [
                 {
@@ -142,9 +142,9 @@ def mock_logging_service():
     """
     Mock logging service to avoid database writes during tests.
     """
-    with patch("api.search_routes.log_query") as mock_log_query, \
-         patch("api.search_routes.log_interaction") as mock_log_interaction, \
-         patch("api.search_routes.log_feedback") as mock_log_feedback:
+    with patch("backend.api.search_routes.log_query") as mock_log_query, \
+         patch("backend.api.search_routes.log_interaction") as mock_log_interaction, \
+         patch("backend.api.search_routes.log_feedback") as mock_log_feedback:
         yield {
             "log_query": mock_log_query,
             "log_interaction": mock_log_interaction,

--- a/backend/tests/test_build_user_profiles.py
+++ b/backend/tests/test_build_user_profiles.py
@@ -9,15 +9,15 @@ from io import StringIO
 class TestRunProfileBuild:
     """Test cases for the run_profile_build script function."""
 
-    @patch("scripts.build_user_profiles.queries_col")
-    @patch("scripts.build_user_profiles.build_user_profile")
+    @patch("backend.scripts.build_user_profiles.queries_col")
+    @patch("backend.scripts.build_user_profiles.build_user_profile")
     def test_no_users_found(self, mock_build, mock_queries_col, capsys):
         """When there are no users, run_profile_build should print zero users and not build any profiles."""
         # Arrange
         mock_queries_col.distinct.return_value = []
 
         # Act
-        from scripts.build_user_profiles import run_profile_build
+        from backend.scripts.build_user_profiles import run_profile_build
         run_profile_build()
 
         # Assert
@@ -27,8 +27,8 @@ class TestRunProfileBuild:
         assert "Found 0 users" in captured.out
         assert "Done building all user profiles" in captured.out
 
-    @patch("scripts.build_user_profiles.queries_col")
-    @patch("scripts.build_user_profiles.build_user_profile")
+    @patch("backend.scripts.build_user_profiles.queries_col")
+    @patch("backend.scripts.build_user_profiles.build_user_profile")
     def test_single_user(self, mock_build, mock_queries_col, capsys):
         """With one user, build_user_profile should be called exactly once."""
         # Arrange
@@ -38,7 +38,7 @@ class TestRunProfileBuild:
         }
 
         # Act
-        from scripts.build_user_profiles import run_profile_build
+        from backend.scripts.build_user_profiles import run_profile_build
         run_profile_build()
 
         # Assert
@@ -48,8 +48,8 @@ class TestRunProfileBuild:
         assert "user_1" in captured.out
         assert "2 implicit interests" in captured.out
 
-    @patch("scripts.build_user_profiles.queries_col")
-    @patch("scripts.build_user_profiles.build_user_profile")
+    @patch("backend.scripts.build_user_profiles.queries_col")
+    @patch("backend.scripts.build_user_profiles.build_user_profile")
     def test_multiple_users(self, mock_build, mock_queries_col, capsys):
         """With multiple users, build_user_profile should be called once per user."""
         # Arrange
@@ -62,7 +62,7 @@ class TestRunProfileBuild:
         ]
 
         # Act
-        from scripts.build_user_profiles import run_profile_build
+        from backend.scripts.build_user_profiles import run_profile_build
         run_profile_build()
 
         # Assert
@@ -76,8 +76,8 @@ class TestRunProfileBuild:
         assert "2 implicit interests" in captured.out   # user_b
         assert "0 implicit interests" in captured.out   # user_c
 
-    @patch("scripts.build_user_profiles.queries_col")
-    @patch("scripts.build_user_profiles.build_user_profile")
+    @patch("backend.scripts.build_user_profiles.queries_col")
+    @patch("backend.scripts.build_user_profiles.build_user_profile")
     def test_calls_in_order(self, mock_build, mock_queries_col):
         """build_user_profile should be called in the same order users are returned."""
         # Arrange
@@ -86,15 +86,15 @@ class TestRunProfileBuild:
         mock_build.return_value = {"implicit_interests": {}}
 
         # Act
-        from scripts.build_user_profiles import run_profile_build
+        from backend.scripts.build_user_profiles import run_profile_build
         run_profile_build()
 
         # Assert
         expected_calls = [call("alpha"), call("bravo"), call("charlie")]
         assert mock_build.call_args_list == expected_calls
 
-    @patch("scripts.build_user_profiles.queries_col")
-    @patch("scripts.build_user_profiles.build_user_profile")
+    @patch("backend.scripts.build_user_profiles.queries_col")
+    @patch("backend.scripts.build_user_profiles.build_user_profile")
     def test_build_failure_propagates(self, mock_build, mock_queries_col):
         """If build_user_profile raises an exception it should propagate up."""
         # Arrange
@@ -102,12 +102,12 @@ class TestRunProfileBuild:
         mock_build.side_effect = RuntimeError("DB connection lost")
 
         # Act / Assert
-        from scripts.build_user_profiles import run_profile_build
+        from backend.scripts.build_user_profiles import run_profile_build
         with pytest.raises(RuntimeError, match="DB connection lost"):
             run_profile_build()
 
-    @patch("scripts.build_user_profiles.queries_col")
-    @patch("scripts.build_user_profiles.build_user_profile")
+    @patch("backend.scripts.build_user_profiles.queries_col")
+    @patch("backend.scripts.build_user_profiles.build_user_profile")
     def test_output_shows_partial_interests(self, mock_build, mock_queries_col, capsys):
         """Output should include a slice of the implicit interests items."""
         # Arrange
@@ -116,7 +116,7 @@ class TestRunProfileBuild:
         mock_build.return_value = {"implicit_interests": interests}
 
         # Act
-        from scripts.build_user_profiles import run_profile_build
+        from backend.scripts.build_user_profiles import run_profile_build
         run_profile_build()
 
         # Assert – the script prints the first 8 items followed by "..."
@@ -124,15 +124,15 @@ class TestRunProfileBuild:
         assert "..." in captured.out
         assert "10 implicit interests" in captured.out
 
-    @patch("scripts.build_user_profiles.queries_col")
-    @patch("scripts.build_user_profiles.build_user_profile")
+    @patch("backend.scripts.build_user_profiles.queries_col")
+    @patch("backend.scripts.build_user_profiles.build_user_profile")
     def test_distinct_called_with_correct_field(self, mock_build, mock_queries_col):
         """queries_col.distinct should be called with 'user_id'."""
         # Arrange
         mock_queries_col.distinct.return_value = []
 
         # Act
-        from scripts.build_user_profiles import run_profile_build
+        from backend.scripts.build_user_profiles import run_profile_build
         run_profile_build()
 
         # Assert

--- a/backend/tests/test_data_models.py
+++ b/backend/tests/test_data_models.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-from models.data_models import (
+from backend.models.data_models import (
     make_query_doc,
     make_interaction_doc,
     make_user_profile_doc,

--- a/backend/tests/test_logging_service.py
+++ b/backend/tests/test_logging_service.py
@@ -15,8 +15,8 @@ class TestLogQuery:
         # Arrange
         mock_queries_col = MagicMock()
         
-        with patch("services.logging_service.queries_col", mock_queries_col), \
-             patch("services.logging_service.make_query_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.queries_col", mock_queries_col), \
+             patch("backend.services.logging_service.make_query_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "generated_id_123",
@@ -27,7 +27,7 @@ class TestLogQuery:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_query
+            from backend.services.logging_service import log_query
             
             # Act
             result = log_query("user_123", "python tutorials")
@@ -42,8 +42,8 @@ class TestLogQuery:
         # Arrange
         mock_queries_col = MagicMock()
         
-        with patch("services.logging_service.queries_col", mock_queries_col), \
-             patch("services.logging_service.make_query_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.queries_col", mock_queries_col), \
+             patch("backend.services.logging_service.make_query_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "generated_id_456",
@@ -54,7 +54,7 @@ class TestLogQuery:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_query
+            from backend.services.logging_service import log_query
             
             # Act
             result = log_query(
@@ -78,8 +78,8 @@ class TestLogQuery:
         mock_queries_col = MagicMock()
         raw_text = "C++ programming language guide"
         
-        with patch("services.logging_service.queries_col", mock_queries_col), \
-             patch("services.logging_service.make_query_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.queries_col", mock_queries_col), \
+             patch("backend.services.logging_service.make_query_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "id_789",
@@ -90,7 +90,7 @@ class TestLogQuery:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_query
+            from backend.services.logging_service import log_query
             
             # Act
             log_query("user_789", raw_text)
@@ -105,8 +105,8 @@ class TestLogQuery:
         mock_queries_col = MagicMock()
         mock_queries_col.insert_one.side_effect = Exception("Database connection error")
         
-        with patch("services.logging_service.queries_col", mock_queries_col), \
-             patch("services.logging_service.make_query_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.queries_col", mock_queries_col), \
+             patch("backend.services.logging_service.make_query_doc") as mock_make_doc:
             
             mock_make_doc.return_value = {
                 "_id": "id_error",
@@ -116,7 +116,7 @@ class TestLogQuery:
                 "timestamp": datetime.now(timezone.utc).isoformat()
             }
             
-            from services.logging_service import log_query
+            from backend.services.logging_service import log_query
             
             # Act & Assert
             with pytest.raises(Exception) as exc_info:
@@ -129,8 +129,8 @@ class TestLogQuery:
         # Arrange
         mock_queries_col = MagicMock()
         
-        with patch("services.logging_service.queries_col", mock_queries_col), \
-             patch("services.logging_service.make_query_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.queries_col", mock_queries_col), \
+             patch("backend.services.logging_service.make_query_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "id_empty",
@@ -141,7 +141,7 @@ class TestLogQuery:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_query
+            from backend.services.logging_service import log_query
             
             # Act
             result = log_query("user_empty", "")
@@ -159,8 +159,8 @@ class TestLogInteraction:
         # Arrange
         mock_interactions_col = MagicMock()
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "interaction_123",
@@ -173,7 +173,7 @@ class TestLogInteraction:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_interaction
+            from backend.services.logging_service import log_interaction
             
             # Act
             result = log_interaction(
@@ -198,8 +198,8 @@ class TestLogInteraction:
         # Arrange
         mock_interactions_col = MagicMock()
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             for rank in [1, 5, 10, 50]:
                 mock_make_doc.reset_mock()
@@ -216,7 +216,7 @@ class TestLogInteraction:
                 }
                 mock_make_doc.return_value = mock_doc
                 
-                from services.logging_service import log_interaction
+                from backend.services.logging_service import log_interaction
                 
                 # Act
                 result = log_interaction(
@@ -235,8 +235,8 @@ class TestLogInteraction:
         mock_interactions_col = MagicMock()
         url = "https://docs.python.org/3/tutorial/index.html?highlight=classes#section"
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "interaction_url",
@@ -249,7 +249,7 @@ class TestLogInteraction:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_interaction
+            from backend.services.logging_service import log_interaction
             
             # Act
             log_interaction("user_url", "query_url", url, 3)
@@ -264,8 +264,8 @@ class TestLogInteraction:
         mock_interactions_col = MagicMock()
         mock_interactions_col.insert_one.side_effect = Exception("Write operation failed")
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_make_doc.return_value = {
                 "_id": "id_error",
@@ -277,7 +277,7 @@ class TestLogInteraction:
                 "action_type": "click"
             }
             
-            from services.logging_service import log_interaction
+            from backend.services.logging_service import log_interaction
             
             # Act & Assert
             with pytest.raises(Exception) as exc_info:
@@ -295,8 +295,8 @@ class TestLogFeedback:
         mock_interactions_col = MagicMock()
         mock_interactions_col.delete_many.return_value = MagicMock(deleted_count=0)
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "feedback_pos_123",
@@ -309,7 +309,7 @@ class TestLogFeedback:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_feedback
+            from backend.services.logging_service import log_feedback
             
             # Act
             result = log_feedback(
@@ -337,8 +337,8 @@ class TestLogFeedback:
         mock_interactions_col = MagicMock()
         mock_interactions_col.delete_many.return_value = MagicMock(deleted_count=0)
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "feedback_neg_456",
@@ -351,7 +351,7 @@ class TestLogFeedback:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_feedback
+            from backend.services.logging_service import log_feedback
             
             # Act
             result = log_feedback(
@@ -378,8 +378,8 @@ class TestLogFeedback:
         mock_interactions_col = MagicMock()
         mock_interactions_col.delete_many.return_value = MagicMock(deleted_count=1)
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "new_feedback",
@@ -392,7 +392,7 @@ class TestLogFeedback:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_feedback
+            from backend.services.logging_service import log_feedback
             
             # Act
             log_feedback(
@@ -418,8 +418,8 @@ class TestLogFeedback:
         
         url = "https://example.com/toggle-result"
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_doc = {
                 "_id": "toggled_feedback",
@@ -432,7 +432,7 @@ class TestLogFeedback:
             }
             mock_make_doc.return_value = mock_doc
             
-            from services.logging_service import log_feedback
+            from backend.services.logging_service import log_feedback
             
             # Act - User changes from positive to negative
             result = log_feedback(
@@ -456,8 +456,8 @@ class TestLogFeedback:
         mock_interactions_col = MagicMock()
         mock_interactions_col.delete_many.side_effect = Exception("Delete operation failed")
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col):
-            from services.logging_service import log_feedback
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col):
+            from backend.services.logging_service import log_feedback
             
             # Act & Assert
             with pytest.raises(Exception) as exc_info:
@@ -478,8 +478,8 @@ class TestLogFeedback:
         mock_interactions_col.delete_many.return_value = MagicMock(deleted_count=0)
         mock_interactions_col.insert_one.side_effect = Exception("Insert operation failed")
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_make_doc.return_value = {
                 "_id": "id_insert_error",
@@ -491,7 +491,7 @@ class TestLogFeedback:
                 "action_type": "positive_feedback"
             }
             
-            from services.logging_service import log_feedback
+            from backend.services.logging_service import log_feedback
             
             # Act & Assert
             with pytest.raises(Exception) as exc_info:
@@ -521,11 +521,11 @@ class TestLoggingDataIntegrity:
         
         mock_queries_col.insert_one.side_effect = capture_doc
         
-        with patch("services.logging_service.queries_col", mock_queries_col):
-            from services.logging_service import log_query
-            from models.data_models import make_query_doc
+        with patch("backend.services.logging_service.queries_col", mock_queries_col):
+            from backend.services.logging_service import log_query
+            from backend.models.data_models import make_query_doc
             
-            with patch("services.logging_service.make_query_doc", wraps=make_query_doc) as wrapped:
+            with patch("backend.services.logging_service.make_query_doc", wraps=make_query_doc) as wrapped:
                 # Act
                 try:
                     log_query("test_user", "test query", "enhanced test query")
@@ -540,11 +540,11 @@ class TestLoggingDataIntegrity:
         # Arrange
         mock_interactions_col = MagicMock()
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col):
-            from services.logging_service import log_interaction
-            from models.data_models import make_interaction_doc
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col):
+            from backend.services.logging_service import log_interaction
+            from backend.models.data_models import make_interaction_doc
             
-            with patch("services.logging_service.make_interaction_doc", wraps=make_interaction_doc) as wrapped:
+            with patch("backend.services.logging_service.make_interaction_doc", wraps=make_interaction_doc) as wrapped:
                 # Act
                 try:
                     log_interaction("test_user", "test_query_id", "https://example.com", 5)
@@ -560,8 +560,8 @@ class TestLoggingDataIntegrity:
         mock_interactions_col = MagicMock()
         mock_interactions_col.delete_many.return_value = MagicMock(deleted_count=0)
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col), \
-             patch("services.logging_service.make_interaction_doc") as mock_make_doc:
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col), \
+             patch("backend.services.logging_service.make_interaction_doc") as mock_make_doc:
             
             mock_make_doc.return_value = {
                 "_id": "test_id",
@@ -573,7 +573,7 @@ class TestLoggingDataIntegrity:
                 "action_type": "positive_feedback"
             }
             
-            from services.logging_service import log_feedback
+            from backend.services.logging_service import log_feedback
             
             # Act - Positive feedback
             log_feedback("user", "query", "https://example.com", 1, is_positive=True)
@@ -618,11 +618,11 @@ class TestSearchResultRelevance:
         
         mock_interactions_col.insert_one.side_effect = capture_rank
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col):
-            from services.logging_service import log_interaction
-            from models.data_models import make_interaction_doc
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col):
+            from backend.services.logging_service import log_interaction
+            from backend.models.data_models import make_interaction_doc
             
-            with patch("services.logging_service.make_interaction_doc", wraps=make_interaction_doc):
+            with patch("backend.services.logging_service.make_interaction_doc", wraps=make_interaction_doc):
                 # Act - Log clicks at different positions
                 for rank in [1, 3, 7, 10]:
                     try:
@@ -648,11 +648,11 @@ class TestSearchResultRelevance:
         
         mock_interactions_col.insert_one.side_effect = capture_action_type
         
-        with patch("services.logging_service.interactions_col", mock_interactions_col):
-            from services.logging_service import log_feedback
-            from models.data_models import make_interaction_doc
+        with patch("backend.services.logging_service.interactions_col", mock_interactions_col):
+            from backend.services.logging_service import log_feedback
+            from backend.models.data_models import make_interaction_doc
             
-            with patch("services.logging_service.make_interaction_doc", wraps=make_interaction_doc):
+            with patch("backend.services.logging_service.make_interaction_doc", wraps=make_interaction_doc):
                 # Act - Log positive and negative feedback
                 try:
                     log_feedback("user", "query", "https://good.com", 1, is_positive=True)
@@ -678,11 +678,11 @@ class TestSearchResultRelevance:
         
         mock_queries_col.insert_one.side_effect = capture_doc
         
-        with patch("services.logging_service.queries_col", mock_queries_col):
-            from services.logging_service import log_query
-            from models.data_models import make_query_doc
+        with patch("backend.services.logging_service.queries_col", mock_queries_col):
+            from backend.services.logging_service import log_query
+            from backend.models.data_models import make_query_doc
             
-            with patch("services.logging_service.make_query_doc", wraps=make_query_doc):
+            with patch("backend.services.logging_service.make_query_doc", wraps=make_query_doc):
                 # Act
                 try:
                     log_query(

--- a/backend/tests/test_profile_routes.py
+++ b/backend/tests/test_profile_routes.py
@@ -3,7 +3,7 @@ Tests for user profile routes (/profiles/*).
 """
 import pytest
 from unittest.mock import patch, Mock
-from api.utils import get_user_id_from_auth, require_user_id_from_auth
+from backend.api.utils import get_user_id_from_auth, require_user_id_from_auth
 
 
 class TestProfileRoutes:
@@ -12,7 +12,7 @@ class TestProfileRoutes:
     def test_get_user_profile_by_id(self, client, mock_user_profile):
         """Test retrieving any user's profile by user_id."""
         # Arrange
-        with patch("services.user_profile_service.build_user_profile", return_value=mock_user_profile):
+        with patch("backend.services.user_profile_service.build_user_profile", return_value=mock_user_profile):
             
             # Act
             response = client.get("/profiles/test_user_123")
@@ -26,7 +26,7 @@ class TestProfileRoutes:
     def test_add_explicit_interest_missing_keyword(self, client):
         """Test adding explicit interest without keyword fails."""
         # Arrange
-        with patch("api.utils.get_user_id_from_auth", return_value="test_user_123"):
+        with patch("backend.api.utils.get_user_id_from_auth", return_value="test_user_123"):
             payload = {
                 "weight": 1.0
             }
@@ -40,7 +40,7 @@ class TestProfileRoutes:
     def test_profile_endpoint_returns_correct_structure(self, client, mock_user_profile):
         """Test that profile response has the expected structure."""
         # Arrange
-        with patch("services.user_profile_service.build_user_profile", return_value=mock_user_profile):
+        with patch("backend.services.user_profile_service.build_user_profile", return_value=mock_user_profile):
             
             # Act
             response = client.get("/profiles/test_user_123")
@@ -64,7 +64,7 @@ class TestProfileRoutes:
     def test_profile_implicit_interests_as_dict(self, client, mock_user_profile):
         """Test that implicit_interests is returned as a dictionary."""
         # Arrange
-        with patch("services.user_profile_service.build_user_profile", return_value=mock_user_profile):
+        with patch("backend.services.user_profile_service.build_user_profile", return_value=mock_user_profile):
             
             # Act
             response = client.get("/profiles/test_user_123")
@@ -142,7 +142,7 @@ class TestMultiUserProfileIsolation:
                 return user_b_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_a = client.get("/profiles/user_a_123")
             response_b = client.get("/profiles/user_b_456")
@@ -180,7 +180,7 @@ class TestMultiUserProfileIsolation:
                 return user_b_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_b = client.get("/profiles/user_b_456")
 
@@ -208,7 +208,7 @@ class TestMultiUserProfileIsolation:
                 return user_b_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_b = client.get("/profiles/user_b_456")
 
@@ -233,7 +233,7 @@ class TestMultiUserProfileIsolation:
                 return user_b_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_a = client.get("/profiles/user_a_123")
             response_b = client.get("/profiles/user_b_456")
@@ -262,7 +262,7 @@ class TestMultiUserProfileIsolation:
                 return user_b_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_a = client.get("/profiles/user_a_123")
             response_b = client.get("/profiles/user_b_456")
@@ -305,8 +305,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             
             # Act - Add interest to User A
             response_add = client.post("/profiles/explicit/add", json={
@@ -348,8 +348,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             
             # Act - Remove interest from User A
             response_remove = client.request("DELETE", "/profiles/explicit/remove", json={
@@ -391,8 +391,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             
             # Act - Bulk update User A
             response_update = client.put("/profiles/explicit/bulk_update", json={
@@ -427,7 +427,7 @@ class TestMultiUserProfileIsolation:
                 return user_b_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_a = client.get("/profiles/user_a_123")
             response_b = client.get("/profiles/user_b_456")
@@ -453,7 +453,7 @@ class TestMultiUserProfileIsolation:
                 return user_c_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response = client.get("/profiles/guest")
 
@@ -477,7 +477,7 @@ class TestMultiUserProfileIsolation:
                 return user_c_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_auth = client.get("/profiles/user_a_123")
             response_guest = client.get("/profiles/guest")
@@ -502,7 +502,7 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[require_user_id_from_auth] = override_require_user_id
 
-        with patch("api.profile_routes.build_user_profile", return_value=user_a_profile):
+        with patch("backend.api.profile_routes.build_user_profile", return_value=user_a_profile):
             # Act
             response = client.get("/profiles/me")
 
@@ -519,7 +519,7 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[require_user_id_from_auth] = override_require_user_id_a
         
-        with patch("api.profile_routes.build_user_profile", return_value=user_a_profile):
+        with patch("backend.api.profile_routes.build_user_profile", return_value=user_a_profile):
             response_a = client.get("/profiles/me")
 
         # Arrange & Act - User B
@@ -528,7 +528,7 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[require_user_id_from_auth] = override_require_user_id_b
         
-        with patch("api.profile_routes.build_user_profile", return_value=user_b_profile):
+        with patch("backend.api.profile_routes.build_user_profile", return_value=user_b_profile):
             response_b = client.get("/profiles/me")
 
         # Assert
@@ -561,8 +561,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             
             # Act - Clear User A's explicit interests
             response_clear = client.post("/profiles/explicit/clear", json={})
@@ -600,8 +600,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             mock_col.find_one.return_value = user_a_profile
             
             # Act - Clear User A's implicit interests
@@ -645,8 +645,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             mock_col.find_one.return_value = user_a_profile
             
             # Act - Upgrade implicit interest for User A
@@ -679,7 +679,7 @@ class TestMultiUserProfileIsolation:
                 return user_c_profile
             return None
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile):
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile):
             # Act
             response_a = client.get("/profiles/user_a_123")
             response_b = client.get("/profiles/user_b_456")
@@ -731,8 +731,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             mock_col.find_one.return_value = user_a_profile
             
             # Act
@@ -772,8 +772,8 @@ class TestMultiUserProfileIsolation:
 
         test_app.dependency_overrides[get_user_id_from_auth] = override_get_user_id
 
-        with patch("api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
-             patch("api.profile_routes.user_profiles_col") as mock_col:
+        with patch("backend.api.profile_routes.build_user_profile", side_effect=mock_build_profile), \
+             patch("backend.api.profile_routes.user_profiles_col") as mock_col:
             mock_col.find_one.return_value = user_a_profile
             
             # Act

--- a/backend/tests/test_search_routes.py
+++ b/backend/tests/test_search_routes.py
@@ -11,7 +11,7 @@ class TestSearchRoutes:
     def test_search_without_enhanced_mode(self, client, mock_search_service, mock_logging_service):
         """Test search without semantic enhancement."""
         # Arrange
-        with patch("api.utils.get_user_id_from_auth", return_value="guest"):
+        with patch("backend.api.utils.get_user_id_from_auth", return_value="guest"):
             # Act
             response = client.get("/search?q=test+query&use_enhanced=false")
         
@@ -31,7 +31,7 @@ class TestSearchRoutes:
     def test_search_with_verbosity_settings(self, client, mock_search_service, mock_logging_service):
         """Test search with different verbosity levels."""
         # Arrange
-        with patch("api.utils.get_user_id_from_auth", return_value="test_user_123"):
+        with patch("backend.api.utils.get_user_id_from_auth", return_value="test_user_123"):
             # Act - Test high verbosity
             response = client.get("/search?q=test&verbosity=high")
         
@@ -43,7 +43,7 @@ class TestSearchRoutes:
     def test_search_with_semantic_modes(self, client, mock_search_service, mock_logging_service):
         """Test search with different semantic modes."""
         # Arrange
-        with patch("api.utils.get_user_id_from_auth", return_value="test_user_123"):
+        with patch("backend.api.utils.get_user_id_from_auth", return_value="test_user_123"):
             # Act - Test clarify_and_personalize mode
             response = client.get("/search?q=test&semantic_mode=clarify_and_personalize")
         
@@ -55,7 +55,7 @@ class TestSearchRoutes:
     def test_search_empty_query(self, client, mock_search_service, mock_logging_service):
         """Test search with an empty query string."""
         # Arrange
-        with patch("api.utils.get_user_id_from_auth", return_value="guest"):
+        with patch("backend.api.utils.get_user_id_from_auth", return_value="guest"):
             # Act
             response = client.get("/search?q=")
         
@@ -67,7 +67,7 @@ class TestSearchRoutes:
     def test_search_authenticated_user(self, client, mock_search_service, mock_logging_service):
         """Test search endpoint with authenticated user."""
         # Arrange
-        with patch("api.utils.get_user_id_from_auth", return_value="authenticated_user_456"):
+        with patch("backend.api.utils.get_user_id_from_auth", return_value="authenticated_user_456"):
             # Act
             response = client.get("/search?q=machine+learning")
         
@@ -81,7 +81,7 @@ class TestSearchRoutes:
     def test_search_special_characters(self, client, mock_search_service, mock_logging_service):
         """Test search with special characters in query."""
         # Arrange
-        with patch("api.utils.get_user_id_from_auth", return_value="guest"):
+        with patch("backend.api.utils.get_user_id_from_auth", return_value="guest"):
             # Act
             response = client.get("/search?q=C%2B%2B+programming")  # C++ encoded
         


### PR DESCRIPTION
Summary
Fixes the AttributeError: module 'services' has no attribute 'db' error when running tests.

Root Cause
All source code uses backend prefixed imports, but the test runner was executing from inside the backend, and all patch targets were missing the backend prefix.

Changes
- backend__init__.py makes backend a proper Python package
- Updated backendrun_tests.py now runs from the project root so backend is importable
- Updated backendpytest.init testpaths changed from tests to backendtests
- Updated backendtestsconftest.py all patch targets and imports prefixed with backend
- Updated all 5 test files every patch target and inline import now uses the backend prefix

Testing
All 91 tests pass after the changes.